### PR TITLE
Add automatic consultorio assignment for public turnos

### DIFF
--- a/src/routes/turnoRoutes.js
+++ b/src/routes/turnoRoutes.js
@@ -52,6 +52,15 @@ router.post('/publico',
 );
 
 /**
+ * @route   POST /api/turnos/publico/auto
+ * @desc    Crear turno con asignación automática de consultorio (para usuarios públicos)
+ * @access  Public
+ */
+router.post('/publico/auto',
+  turnoController.createTurnoPublicoAuto
+);
+
+/**
  * @route   GET /api/turnos
  * @desc    Obtener todos los turnos con filtros
  * @access  Private (Admin)


### PR DESCRIPTION
Introduces endpoint and controller logic to create public turnos with automatic consultorio assignment based on availability. Adds Consultorio.getMostAvailable method to select the consultorio with the fewest turnos in waiting, improving user experience for public turnos.